### PR TITLE
transfer lamports into test user account to prevent silent TX rejection

### DIFF
--- a/program/tests/test_srm.rs
+++ b/program/tests/test_srm.rs
@@ -1,19 +1,18 @@
 // Tests related to the SRM vault of a MangoGroup
-#![cfg(feature="test-bpf")]
+#![cfg(feature = "test-bpf")]
 
 mod helpers;
 
-use std::mem::size_of;
 use helpers::*;
+use solana_program::account_info::AccountInfo;
 use solana_program_test::*;
 use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{Signer, Keypair},
-    system_instruction::transfer,
-    transaction::Transaction,
     account::Account,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
 };
-use solana_program::account_info::AccountInfo;
+use std::mem::size_of;
 
 use mango::{
     entrypoint::process_instruction,
@@ -26,68 +25,79 @@ async fn test_deposit_srm() {
     // Test that the DepositSrm instruction succeeds in the simple case
     let program_id = Pubkey::new_unique();
 
-    let mut test = ProgramTest::new(
-        "mango",
-        program_id,
-        processor!(process_instruction),
-    );
+    let mut test = ProgramTest::new("mango", program_id, processor!(process_instruction));
 
     // limit to track compute unit increase
     test.set_bpf_compute_max_units(50_000);
 
     let initial_amount = 500;
     let deposit_amount = 100;
+    let withdraw_amount = 10;
 
     let user = Keypair::new();
     let user_pk = user.pubkey();
     let mango_group = add_mango_group_prodlike(&mut test, program_id);
     let mango_srm_account_pk = Pubkey::new_unique();
-    test.add_account(mango_srm_account_pk, Account::new(u32::MAX as u64, size_of::<MangoSrmAccount>(), &program_id));
-    let user_srm_account = add_token_account(&mut test, user_pk, mango_group.srm_mint.pubkey, initial_amount);
+    test.add_account(
+        mango_srm_account_pk,
+        Account::new(u32::MAX as u64, size_of::<MangoSrmAccount>(), &program_id),
+    );
+    let user_srm_account = add_token_account(
+        &mut test,
+        user_pk,
+        mango_group.srm_mint.pubkey,
+        initial_amount,
+    );
 
     let (mut banks_client, payer, recent_blockhash) = test.start().await;
 
-    let mut transaction = Transaction::new_with_payer(
-        &[
-            mango_group.init_mango_group(&payer.pubkey()),
+    {
+        let mut transaction = Transaction::new_with_payer(
+            &[
+                mango_group.init_mango_group(&payer.pubkey()),
+                deposit_srm(
+                    &program_id,
+                    &mango_group.mango_group_pk,
+                    &mango_srm_account_pk,
+                    &user_pk,
+                    &user_srm_account.pubkey,
+                    &mango_group.srm_vault.pubkey,
+                    deposit_amount,
+                )
+                .unwrap(),
+            ],
+            Some(&payer.pubkey()),
+        );
 
-            deposit_srm(
-                &program_id,
-                &mango_group.mango_group_pk,
-                &mango_srm_account_pk,
-                &user_pk,
-                &user_srm_account.pubkey,
-                &mango_group.srm_vault.pubkey,
-                deposit_amount,
-            ).unwrap(),
-        ],
-        Some(&payer.pubkey()),
-    );
+        transaction.sign(&[&payer, &user], recent_blockhash);
+        assert!(banks_client.process_transaction(transaction).await.is_ok());
 
-    transaction.sign(
-        &[&payer, &user],
-        recent_blockhash,
-    );
-    assert!(banks_client.process_transaction(transaction).await.is_ok());
+        let final_user_balance =
+            get_token_balance(&mut banks_client, user_srm_account.pubkey).await;
+        assert_eq!(final_user_balance, initial_amount - deposit_amount);
+        let mango_vault_srm_balance =
+            get_token_balance(&mut banks_client, mango_group.srm_vault.pubkey).await;
+        assert_eq!(mango_vault_srm_balance, deposit_amount);
 
-    let final_user_balance = get_token_balance(&mut banks_client, user_srm_account.pubkey).await;
-    assert_eq!(final_user_balance, initial_amount - deposit_amount);
-    let mango_vault_srm_balance = get_token_balance(&mut banks_client, mango_group.srm_vault.pubkey).await;
-    assert_eq!(mango_vault_srm_balance, deposit_amount);
+        let mut mango_srm_account = banks_client
+            .get_account(mango_srm_account_pk)
+            .await
+            .unwrap()
+            .unwrap();
+        let account_info: AccountInfo = (&mango_srm_account_pk, &mut mango_srm_account).into();
 
-    let mut mango_srm_account = banks_client.get_account(mango_srm_account_pk).await.unwrap().unwrap();
-    let account_info: AccountInfo = (&mango_srm_account_pk, &mut mango_srm_account).into();
+        let mango_srm_account = MangoSrmAccount::load_mut_checked(
+            &program_id,
+            &account_info,
+            &mango_group.mango_group_pk,
+        )
+        .unwrap();
+        assert_eq!(mango_srm_account.amount, deposit_amount);
+    }
 
-    let mango_srm_account = MangoSrmAccount::load_mut_checked(
-        &program_id,
-        &account_info,
-        &mango_group.mango_group_pk,
-    ).unwrap();
-    assert_eq!(mango_srm_account.amount, deposit_amount);
-
-    let mut transaction2 = Transaction::new_with_payer(
-        &[
-            withdraw_srm(
+    {
+        let mut transaction = Transaction::new_with_payer(
+            &[withdraw_srm(
                 &program_id,
                 &mango_group.mango_group_pk,
                 &mango_srm_account_pk,
@@ -95,11 +105,37 @@ async fn test_deposit_srm() {
                 &user_srm_account.pubkey,
                 &mango_group.srm_vault.pubkey,
                 &mango_group.signer_pk,
-                50,
-            ).unwrap(),
-        ],
-        Some(&payer.pubkey()),
-    );
-    transaction2.sign(&[&user, &payer], recent_blockhash);
-    assert!(banks_client.process_transaction(transaction2).await.is_ok());
+                withdraw_amount,
+            )
+            .unwrap()],
+            Some(&payer.pubkey()),
+        );
+        transaction.sign(&[&user, &payer], recent_blockhash);
+        assert!(banks_client.process_transaction(transaction).await.is_ok());
+
+        let final_user_balance =
+            get_token_balance(&mut banks_client, user_srm_account.pubkey).await;
+        assert_eq!(
+            final_user_balance,
+            initial_amount - deposit_amount + withdraw_amount
+        );
+        let mango_vault_srm_balance =
+            get_token_balance(&mut banks_client, mango_group.srm_vault.pubkey).await;
+        assert_eq!(mango_vault_srm_balance, deposit_amount - withdraw_amount);
+
+        let mut mango_srm_account = banks_client
+            .get_account(mango_srm_account_pk)
+            .await
+            .unwrap()
+            .unwrap();
+        let account_info: AccountInfo = (&mango_srm_account_pk, &mut mango_srm_account).into();
+
+        let mango_srm_account = MangoSrmAccount::load_mut_checked(
+            &program_id,
+            &account_info,
+            &mango_group.mango_group_pk,
+        )
+        .unwrap();
+        assert_eq!(mango_srm_account.amount, deposit_amount - withdraw_amount);
+    }
 }

--- a/program/tests/test_srm.rs
+++ b/program/tests/test_srm.rs
@@ -85,26 +85,7 @@ async fn test_deposit_srm() {
     ).unwrap();
     assert_eq!(mango_srm_account.amount, deposit_amount);
 
-    // deposit some SOL in the user's account so he can call withdraw_srm
     let mut transaction2 = Transaction::new_with_payer(
-        &[
-            transfer(
-                &payer.pubkey(),
-                &user_pk,
-                10_000,
-            ),
-        ],
-        Some(&payer.pubkey()),
-    );
-
-    transaction2.sign(
-        &[&payer],
-        recent_blockhash,
-    );
-
-    assert!(banks_client.process_transaction(transaction2).await.is_ok());
-
-    let mut transaction3 = Transaction::new_with_payer(
         &[
             withdraw_srm(
                 &program_id,
@@ -117,8 +98,8 @@ async fn test_deposit_srm() {
                 50,
             ).unwrap(),
         ],
-        Some(&user_pk),
+        Some(&payer.pubkey()),
     );
-    transaction3.sign(&[&user], recent_blockhash);
-    assert!(banks_client.process_transaction(transaction3).await.is_ok());
+    transaction2.sign(&[&user, &payer], recent_blockhash);
+    assert!(banks_client.process_transaction(transaction2).await.is_ok());
 }


### PR DESCRIPTION
@kevlubkcm managed to get the withdraw srm code to work, after transferring the lamports.

afterwards I also tried to just set the payer as an additional signer on withdraw TX and that also seems to work, maybe a bit more easier to read in the end.