### PR TITLE
Liquidation logging

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -464,13 +464,32 @@ impl Processor {
         }
 
         let prices = get_prices(&mango_group, oracle_accs)?;
-        let coll_ratio = liqee_margin_account.get_collateral_ratio(
-            &mango_group, &prices, open_orders_accs
-        )?;
 
-        let starting_assets = liqee_margin_account.get_total_assets(&mango_group, open_orders_accs).unwrap();
-        let starting_liabs = liqee_margin_account.get_total_liabs(&mango_group).unwrap();
-        msg!("Liquidation details: {{ \"assets\": {:?}, \"liabs\": {:?}, \"prices\": {:?}, \"coll_ratio\": {}, \"unused\": {} }}", starting_assets, starting_liabs, prices, coll_ratio, 0);
+        // Need assets and liabs for logging. Calculate collateral ratio from them to save compute cost of calling liqee_margin_account.get_collateral_ratio
+        let assets = liqee_margin_account.get_total_assets(&mango_group, open_orders_accs).unwrap();
+        let liabs = liqee_margin_account.get_total_liabs(&mango_group).unwrap();
+        
+        let mut assets_val: U64F64 = ZERO_U64F64;
+        let mut liabs_val: U64F64 = ZERO_U64F64;
+        for i in 0..NUM_TOKENS {
+            liabs_val +=  U64F64::from_num(liabs[i]).checked_mul(prices[i]).unwrap();
+            assets_val +=  U64F64::from_num(assets[i]).checked_mul(prices[i]).unwrap();
+        }
+
+        let coll_ratio: U64F64;
+        if liabs_val == ZERO_U64F64 {
+            coll_ratio = U64F64::MAX;
+        } else {
+            coll_ratio = assets_val / liabs_val;
+        }
+
+        // Too expensive to call msg! with an argument of type U64F64 - convert to f64 first
+        let mut prices_f64 = [0_f64; NUM_TOKENS];
+        for i in 0..NUM_TOKENS {
+            prices_f64[i] = prices[i].to_num::<f64>();
+        }
+
+        msg!("Liquidation details: {{ \"assets\": {:?}, \"liabs\": {:?}, \"prices\": {:?}, \"coll_ratio\": {}, \"unused\": {} }}", assets, liabs, prices_f64, coll_ratio.to_num::<f64>(), 0);
 
         // No liquidations if account above maint collateral ratio
         check!(coll_ratio < mango_group.maint_coll_ratio, MangoErrorCode::NotLiquidatable)?;
@@ -1357,12 +1376,32 @@ impl Processor {
         let clock = Clock::from_account_info(clock_acc)?;
         mango_group.update_indexes(&clock)?;
         let prices = get_prices(&mango_group, oracle_accs)?;
-        let coll_ratio = liqee_margin_account.get_collateral_ratio(
-            &mango_group, &prices, open_orders_accs)?;
         
-        let starting_assets = liqee_margin_account.get_total_assets(&mango_group, open_orders_accs).unwrap();
-        let starting_liabs = liqee_margin_account.get_total_liabs(&mango_group).unwrap();
-        msg!("Liquidation details: {{ \"assets\": {:?}, \"liabs\": {:?}, \"prices\": {:?}, \"coll_ratio\": {}, \"unused\": {} }}", starting_assets, starting_liabs, prices, coll_ratio, 0);
+        // Need assets and liabs for logging. Calculate collateral ratio from them to save compute cost of calling liqee_margin_account.get_collateral_ratio
+        let assets = liqee_margin_account.get_total_assets(&mango_group, open_orders_accs).unwrap();
+        let liabs = liqee_margin_account.get_total_liabs(&mango_group).unwrap();
+        
+        let mut assets_val: U64F64 = ZERO_U64F64;
+        let mut liabs_val: U64F64 = ZERO_U64F64;
+        for i in 0..NUM_TOKENS {
+            liabs_val +=  U64F64::from_num(liabs[i]).checked_mul(prices[i]).unwrap();
+            assets_val +=  U64F64::from_num(assets[i]).checked_mul(prices[i]).unwrap();
+        }
+
+        let coll_ratio: U64F64;
+        if liabs_val == ZERO_U64F64 {
+            coll_ratio = U64F64::MAX;
+        } else {
+            coll_ratio = assets_val / liabs_val;
+        }
+
+        // Too expensive to call msg! with an argument of type U64F64 - convert to f64 first
+        let mut prices_f64 = [0_f64; NUM_TOKENS];
+        for i in 0..NUM_TOKENS {
+            prices_f64[i] = prices[i].to_num::<f64>();
+        }
+
+        msg!("Liquidation details: {{ \"assets\": {:?}, \"liabs\": {:?}, \"prices\": {:?}, \"coll_ratio\": {}, \"unused\": {} }}", assets, liabs, prices_f64, coll_ratio.to_num::<f64>(), 0);
 
         // Only allow liquidations on accounts already being liquidated and below init or accounts below maint
         if liqee_margin_account.being_liquidated {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -468,6 +468,10 @@ impl Processor {
             &mango_group, &prices, open_orders_accs
         )?;
 
+        let starting_assets = liqee_margin_account.get_total_assets(&mango_group, open_orders_accs).unwrap();
+        let starting_liabs = liqee_margin_account.get_total_liabs(&mango_group).unwrap();
+        msg!("Liquidation details: {{ \"assets\": {:?}, \"liabs\": {:?}, \"prices\": {:?}, \"coll_ratio\": {}, \"unused\": {} }}", starting_assets, starting_liabs, prices, coll_ratio, 0);
+
         // No liquidations if account above maint collateral ratio
         check!(coll_ratio < mango_group.maint_coll_ratio, MangoErrorCode::NotLiquidatable)?;
 
@@ -1355,6 +1359,10 @@ impl Processor {
         let prices = get_prices(&mango_group, oracle_accs)?;
         let coll_ratio = liqee_margin_account.get_collateral_ratio(
             &mango_group, &prices, open_orders_accs)?;
+        
+        let starting_assets = liqee_margin_account.get_total_assets(&mango_group, open_orders_accs).unwrap();
+        let starting_liabs = liqee_margin_account.get_total_liabs(&mango_group).unwrap();
+        msg!("Liquidation details: {{ \"assets\": {:?}, \"liabs\": {:?}, \"prices\": {:?}, \"coll_ratio\": {}, \"unused\": {} }}", starting_assets, starting_liabs, prices, coll_ratio, 0);
 
         // Only allow liquidations on accounts already being liquidated and below init or accounts below maint
         if liqee_margin_account.being_liquidated {


### PR DESCRIPTION
Refactoring to reduce additional compute of adding liquidation logging.

Previously, additional compute was 23k.
Currently, additional compute is 8k (compare no logging 
https://explorer.solana.com/tx/yiwDLcULGyJQ4xkNvGhVS1wRqjcxE8Cu8My9SH7cbjcuXbps2bQ3tQ3u6ZNgEfp3Q16YB5PKYzGxTC8Khk2Mw2f?cluster=devnet to with logging https://explorer.solana.com/tx/3SU5y2dYT5LRHa9cSNG9voScDEAn8hZ16XQSNpQVjrk1zMuwQVhLbMS2WgQaEqCoRhoZ7Q4skZoDXWZyPz1nRZ43?cluster=devnet)


Savings came from two sources:
1) Use assets and liabs (required for logging) to compute collateral ratio. Eliminates redundant call to get_collateral_ratio. Saves about 2k.
2) Passing the price array of type U64F64 to msg! is very expensive. Cast prices to f64 before passing to msg!. Saves about 13k.