### PR TITLE
Add Anchor.toml for publishing verifiable source

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,0 +1,11 @@
+anchor_version = "0.13.2"
+
+[workspace]
+members = ["program", "common"]
+
+[provider]
+cluster = "mainnet"
+wallet = "~/.config/solana/id.json"
+
+[programs.mainnet]
+mango = "5fNfvyp5czQVX77yoACa3JJVEhdRaWjPuazuWgjhTqEH"


### PR DESCRIPTION
Adds an Anchor.toml file for publishing a verifiable build + source to https://anchor.projectserum.com by running in the workspace root

```bash
anchor publish mango
```

Instructions for getting started are here: https://project-serum.github.io/anchor/getting-started/publishing.html. Please use the latest Anchor CLI `v0.13.2`.

Note that in order for the program to be verifiable, it must be built inside a docker image with a Cargo.lock, the latter of which mango already has. When deploying you can do one of two things:

1. Use the publish command. Download the `mango.so` artifact from the registry and deploy via the `solana program deploy` command.
2. Run `anchor build -p mango --verifiable` in the workspace root. A verifiable binary will be built at `target/verifiable/mango.so`. To verify via CLI, run `anchor verify -p mango <program-id>`. When you publish, the binary will match.

